### PR TITLE
add origin_consortium to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -97,10 +97,10 @@
 	},
 	{
 		"value": "threat superiority effect"
-        },		
+        },
 	{
 		"value": "visual search task"
-        },		
+        },
 	{
 		"value": "african"
 	},
@@ -180,6 +180,14 @@
             "values": [
                 {
                     "value": "Quebec"
+                }
+            ]
+        },
+{
+            "category": "origin_consortium",
+            "values": [
+                {
+                    "value": "EEGnet"
                 }
             ]
         },


### PR DESCRIPTION
This PR adds the value "EEGnet" to the `origin_consortium` field in DATS.json.